### PR TITLE
change dtype to pipe directly

### DIFF
--- a/loader.py
+++ b/loader.py
@@ -108,8 +108,7 @@ class OmniGenLoader:
             print(f"Offload Model: {offload_model}")
             
             from OmniGen import OmniGenPipeline
-            pipe = OmniGenPipeline.from_pretrained(model_path)
-            pipe.model = pipe.model.to(dtype)
+            pipe = OmniGenPipeline.from_pretrained(model_path, dtype=dtype)
 
             print(f"After loading: {get_vram_info()}")
 


### PR DESCRIPTION
This is the proper way to load model to a specific dtype with diffusers based pipes iirc.